### PR TITLE
Combined commits

### DIFF
--- a/src/clientversion.cpp
+++ b/src/clientversion.cpp
@@ -12,7 +12,7 @@
  * for both 5gd and 5g-qt, to make it harder for attackers to
  * target servers or GUI users specifically.
  */
-const std::string CLIENT_NAME("Satoshi");
+const std::string CLIENT_NAME("5G");
 
 /**
  * Client version number

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -596,6 +596,7 @@ void SetupServerArgs()
     gArgs.AddArg("-rpcuser=<user>", "Username for JSON-RPC connections", false, OptionsCategory::RPC);
     gArgs.AddArg("-rpcworkqueue=<n>", strprintf("Set the depth of the work queue to service RPC calls (default: %d)", DEFAULT_HTTP_WORKQUEUE), true, OptionsCategory::RPC);
     gArgs.AddArg("-server", "Accept command line and JSON-RPC commands", false, OptionsCategory::RPC);
+    gArgs.AddArg("-stakeinfo", "Add detailed staking information to debug.log", false, OptionsCategory::OPTIONS);
 
     gArgs.AddArg("-sporkkey", "Private key to send spork messages", false, OptionsCategory::OPTIONS);
     gArgs.AddArg("-staking", "Enable staking while working with wallet, default is 1", false, OptionsCategory::OPTIONS);
@@ -1972,7 +1973,7 @@ bool AppInitMain()
     uiInterface.InitMessage(_("Done loading"));
 
     g_wallet_init_interface.Start(scheduler);
-    if(GetWallets().front() && gArgs.GetBoolArg("-staking", true))
+    if(GetWallets().front() && gArgs.GetBoolArg("-staking", true) && !fMasterNode)
     {
         threadGroup.create_thread(std::bind(&ThreadStakeMinter, boost::ref(chainparams), boost::ref(connman), GetWallets().front()));
     }

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -253,6 +253,10 @@ public:
     bool IsValidNetAddr() const;
     static bool IsValidNetAddr(CService addrIn);
 
+    int nLastLogTime{0};
+    bool LastLogCheck();
+    void LastLogSet();
+
     void IncreasePoSeBanScore() { if(nPoSeBanScore < MASTERNODE_POSE_BAN_MAX_SCORE) nPoSeBanScore++; }
     void DecreasePoSeBanScore() { if(nPoSeBanScore > -MASTERNODE_POSE_BAN_MAX_SCORE) nPoSeBanScore--; }
     void PoSeBan() { nPoSeBanScore = MASTERNODE_POSE_BAN_MAX_SCORE; }


### PR DESCRIPTION
   * Update the client name to '5G' from 'Satoshi'
   * Quieten the logs down; particularly CMasternode::Check() which is still allowed to log once every 5 minutes
   * Dont hit nodes with Misbehaving() for relaying dud mn/votes (COutPoint(0000000...., 4294967295)), but dont accept them
   * Dont allow masternodes to stake; collaterals are locked regardless, but the notion is just dim
   * Dont attempt to load stakes into mempool on startup (they will fail anyway)
   * Add stake hashproof debug which is available by launching with --stakeinfo