### PR TITLE
Update dependencies and fix ZMQ thread cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # This is a Dockerfile for fivegd.
-FROM debian:bionic
+FROM debian:bookworm
 
 # Install required system packages
 RUN apt-get update && apt-get install -y \
@@ -12,9 +12,8 @@ RUN apt-get update && apt-get install -y \
     libssl-dev \
     libtool \
     libzmq3-dev \
+    openjdk-17-jdk \
     make \
-    openjdk-8-jdk \
-    pkg-config \
     zlib1g-dev
 
 # Install Berkeley DB 4.8
@@ -63,6 +62,7 @@ RUN apt-get remove -y \
     libssl-dev \
     libtool \
     libzmq3-dev \
+    openjdk-17-jdk \
     make
 
 # Start Fiveg Daemon

--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -1,8 +1,8 @@
 package=boost
-$(package)_version=1_64_0
-$(package)_download_path=http://sourceforge.net/projects/boost/files/boost/1.64.0
+$(package)_version=1_82_0
+$(package)_download_path=http://sourceforge.net/projects/boost/files/boost/1.82.0
 $(package)_file_name=$(package)_$($(package)_version).tar.bz2
-$(package)_sha256_hash=7bcc5caace97baa948931d712ea5f37038dbb1c5d89b43ad4def4ed7cb683332
+$(package)_sha256_hash=a6e1ab9b0860e6a2881dd7b21fe9f737a095e5f33a3a874afc6a345228597ee6
 
 define $(package)_set_vars
 $(package)_config_opts_release=variant=release

--- a/depends/packages/openssl.mk
+++ b/depends/packages/openssl.mk
@@ -1,8 +1,8 @@
 package=openssl
-$(package)_version=1.0.1k
-$(package)_download_path=https://www.openssl.org/source
-$(package)_file_name=$(package)-$($(package)_version).tar.gz
-$(package)_sha256_hash=8f9faeaebad088e772f4ef5e38252d472be4d878c6b3a2718c10a4fcebe7a41c
+$(package)_version=1.1.1w
+$(package)_download_path=https://deb.debian.org/debian/pool/main/o/openssl
+$(package)_file_name=openssl_$($(package)_version).orig.tar.gz
+$(package)_sha256_hash=cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8
 
 define $(package)_set_vars
 $(package)_config_env=AR="$($(package)_ar)" RANLIB="$($(package)_ranlib)" CC="$($(package)_cc)"

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -1,21 +1,22 @@
 PACKAGE=qt
-$(package)_version=5.6.1
-$(package)_download_path=http://download.qt.io/official_releases/qt/5.6/$($(package)_version)/submodules
-$(package)_suffix=opensource-src-$($(package)_version).tar.gz
-$(package)_file_name=qtbase-$($(package)_suffix)
-$(package)_sha256_hash=0ac67cf8d66d52b995f96c31c4b48117a1afb3db99eaa93e20ccd8f7f55f7fde
+$(package)_version=5.15.2
+$(package)_download_path=https://deb.debian.org/debian/pool/main/q
+$(package)_download_file=qtbase-opensource-src/qtbase-opensource-src_$($(package)_version)+dfsg.orig.tar.xz
+$(package)_suffix=opensource-src_$($(package)_version).orig.tar.xz
+$(package)_file_name=qtbase-opensource-src_$($(package)_version)+dfsg.orig.tar.xz
+$(package)_sha256_hash=9ed5e0ab96a04daec5383a5e642d0308ca8246359a4c857a73a5c58d806237bb
 $(package)_dependencies=openssl
 $(package)_linux_dependencies=freetype fontconfig libxcb libX11 xproto libXext
 $(package)_build_subdir=qtbase
 $(package)_qt_libs=corelib network widgets gui plugins testlib
 $(package)_patches=mac-qmake.conf mingw-uuidof.patch pidlist_absolute.patch fix-xcb-include-order.patch fix_qt_pkgconfig.patch
 
-$(package)_qttranslations_file_name=qttranslations-$($(package)_suffix)
-$(package)_qttranslations_sha256_hash=dcc1534d247babca1840cb6d0a000671801a341ea352d0535474f86adadaf028
+$(package)_qttranslations_file_name=qttranslations-opensource-src/qttranslations-opensource-src_$($(package)_version).orig.tar.xz
+$(package)_qttranslations_sha256_hash=d5788e86257b21d5323f1efd94376a213e091d1e5e03b45a95dd052b5f570db8
 
 
-$(package)_qttools_file_name=qttools-$($(package)_suffix)
-$(package)_qttools_sha256_hash=e0f845de28c31230dfa428f0190ccb3b91d1fc02481b1f064698ae4ef8376aa1
+$(package)_qttools_file_name=qttools-opensource-src/qttools-opensource-src_$($(package)_version).orig.tar.xz
+$(package)_qttools_sha256_hash=c189d0ce1ff7c739db9a3ace52ac3e24cb8fd6dbf234e49f075249b38f43c1cc
 
 $(package)_extra_sources  = $($(package)_qttranslations_file_name)
 $(package)_extra_sources += $($(package)_qttools_file_name)

--- a/src/zmqserver/zmqinterface.cpp
+++ b/src/zmqserver/zmqinterface.cpp
@@ -111,6 +111,7 @@ CZMQReplierInterface* CZMQReplierInterface::Create()
 
 CZMQPublisherInterface::CZMQPublisherInterface()
 {
+    worker = nullptr;
 }
 
 bool CZMQPublisherInterface::StartWorker()
@@ -129,8 +130,13 @@ CZMQPublisherInterface::~CZMQPublisherInterface()
         delete *i;
     }
 
-    //destroy worker
-    worker->interrupt();
+    // destroy worker
+    if (worker) {
+        worker->interrupt();
+        worker->join();
+        delete worker;
+        worker = nullptr;
+    }
 }
 
 CZMQPublisherInterface* CZMQPublisherInterface::Create()

--- a/src/zmqserver/zmqinterface.h
+++ b/src/zmqserver/zmqinterface.h
@@ -21,7 +21,7 @@ public:
 
 protected:
     std::list<CZMQAbstract*> notifiers;
-    boost::thread* worker;
+    boost::thread* worker = nullptr;
 };
 
 

--- a/src/zmqserver/zmqreplier.cpp
+++ b/src/zmqserver/zmqreplier.cpp
@@ -10,6 +10,11 @@
 #include "client-api/protocol.h"
 
 //*********** threads waiting for responses ***********//
+CZMQAbstractReplier::CZMQAbstractReplier()
+{
+    worker = nullptr;
+}
+
 void* CZMQOpenReplier::Thread()
 {
     LogPrintf("ZMQ: IN REQREP_ZMQ_open\n");
@@ -200,9 +205,9 @@ bool CZMQAbstractReplier::Initialize()
 void CZMQAbstractReplier::Shutdown()
 {
     LogPrintf("shutting down replier..\n");
-    if (pcontext) // prematurely end context in order to let threads run out
+    if (pcontext) // allow worker thread to exit cleanly
     {
-        pcontext = 0;
+        // context will be destroyed after thread shutdown
     }
 
     KEEPALIVE = 0; // end infinite loop in thread 
@@ -221,6 +226,16 @@ void CZMQAbstractReplier::Shutdown()
     LogPrintf("closed psocket\n");
 
     zmq_ctx_destroy(pcontext);
+    pcontext = 0;
 
     LogPrintf("replier shutdown\n");
+}
+
+CZMQAbstractReplier::~CZMQAbstractReplier()
+{
+    if (worker) {
+        worker->join();
+        delete worker;
+        worker = nullptr;
+    }
 }

--- a/src/zmqserver/zmqreplier.h
+++ b/src/zmqserver/zmqreplier.h
@@ -16,9 +16,12 @@ protected:
     int KEEPALIVE = 1;
     int rc;
     zmq_msg_t request;
-    boost::thread* worker;
+    boost::thread* worker = nullptr;
 
 public:
+    CZMQAbstractReplier();
+    virtual ~CZMQAbstractReplier();
+
     // Initialization
     bool Initialize();
     void Shutdown();


### PR DESCRIPTION
## Summary
- bump Debian base image to bookworm with newer OpenJDK
- update OpenSSL, Boost and Qt versions in depends
- cleanup ZMQ thread handling
- ensure worker threads start as nullptr

## Testing
- `sh autogen.sh` *(fails: Libtool undefined and CXX not found)*
- `make -n` *(fails: no makefile)*

------
https://chatgpt.com/codex/tasks/task_e_684bbff79a0c83319e18ff777851f531