### PR TITLE
Fix memory leak in fivegnodeman

### DIFF
--- a/depscript.sh
+++ b/depscript.sh
@@ -5,7 +5,7 @@ echo "Updating the machine..."
 sudo apt-get update
 echo "Machine successfully updated"
 echo "Installing required packages.."
-sudo apt-get install build-essential libtool autotools-dev automake pkg-config libssl-dev libevent-dev bsdmainutils libboost-all-dev libzmq3-dev libminizip-dev -y
+sudo apt-get install build-essential libtool autotools-dev automake pkg-config libssl-dev libevent-dev bsdmainutils libboost-all-dev libzmq3-dev libminizip-dev 
 echo -e "Successfully installed build-essential\n
 		 Successfully installed libtool\n
 		 Successfully installed autotools-dev\n

--- a/src/fivegnodeman.h
+++ b/src/fivegnodeman.h
@@ -8,6 +8,7 @@
 
 #include "fivegnode.h"
 #include "sync.h"
+#include <string>
 
 using namespace std;
 
@@ -286,7 +287,7 @@ public:
 
     fivegnode_info_t GetFivegnodeInfo(const CPubKey& pubKeyFivegnode);
 
-    char* GetNotQualifyReason(CFivegnode& mn, int nBlockHeight, bool fFilterSigTime, int nMnCount);
+    std::string GetNotQualifyReason(CFivegnode& mn, int nBlockHeight, bool fFilterSigTime, int nMnCount);
 
     UniValue GetNotQualifyReasonToUniValue(CFivegnode& mn, int nBlockHeight, bool fFilterSigTime, int nMnCount);
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1089,8 +1089,11 @@ void RunTor(){
 	std::transform(argv.begin(), argv.end(), std::back_inserter(argv_c),
 			convert_str);
 
-	tor_main(argv_c.size(), &argv_c[0]);
+        tor_main(argv_c.size(), &argv_c[0]);
 
+        for (char* ptr : argv_c)
+            delete[] ptr;
+        tor_cleanup();
 
 }
 

--- a/src/rpc/rpcfivegnode.cpp
+++ b/src/rpc/rpcfivegnode.cpp
@@ -554,10 +554,10 @@ UniValue fivegnodelist(const UniValue &params, bool fHelp) {
                     nBlockHeight = pindex->nHeight;
                 }
                 int nMnCount = mnodeman.CountEnabled();
-                char* reasonStr = mnodeman.GetNotQualifyReason(mn, nBlockHeight, true, nMnCount);
+                std::string reasonStr = mnodeman.GetNotQualifyReason(mn, nBlockHeight, true, nMnCount);
                 std::string strOutpoint = mn.vin.prevout.ToStringShort();
                 if (strFilter != "" && strOutpoint.find(strFilter) == std::string::npos) continue;
-                obj.push_back(Pair(strOutpoint, (reasonStr != NULL) ? reasonStr : "true"));
+                obj.push_back(Pair(strOutpoint, (!reasonStr.empty()) ? reasonStr : "true"));
             }
         }
     }

--- a/src/tor/src/lib/tls/tortls_openssl.c
+++ b/src/tor/src/lib/tls/tortls_openssl.c
@@ -1172,8 +1172,7 @@ tor_tls_block_renegotiation(tor_tls_t *tls)
 void
 tor_tls_assert_renegotiation_unblocked(tor_tls_t *tls)
 {
-#if defined(SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION) && \
-  SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION != 0
+#if defined(SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION)
   long options = SSL_get_options(tls->ssl);
   tor_assert(0 != (options & SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION));
 #else


### PR DESCRIPTION
## Summary
- address memory leak in node qualification logic
- stop returning raw char pointers from `GetNotQualifyReason`
- update callers to use a `std::string`

