### PR TITLE
Allow IPv6 addresses for masternodes

### DIFF
--- a/src/activefivegnode.cpp
+++ b/src/activefivegnode.cpp
@@ -178,7 +178,7 @@ void CActiveFivegnode::ManageStateInitial() {
             // We have some peers, let's try to find our local address from one of them
             BOOST_FOREACH(CNode * pnode, vNodes)
             {
-                if (pnode->fSuccessfullyConnected && pnode->addr.IsIPv4()) {
+                if (pnode->fSuccessfullyConnected) {
                     fFoundLocal = GetLocal(service, &pnode->addr) && CFivegnode::IsValidNetAddr(service);
                     if (fFoundLocal) break;
                 }
@@ -188,7 +188,7 @@ void CActiveFivegnode::ManageStateInitial() {
 
     if (!fFoundLocal) {
         ChangeState(ACTIVE_FIVEGNODE_NOT_CAPABLE);
-        strNotCapableReason = "Can't detect valid external address. Please consider using the externalip configuration option if problem persists. Make sure to use IPv4 address only.";
+        strNotCapableReason = "Can't detect valid external address. Please consider using the externalip configuration option if problem persists. Make sure your address is reachable.";
         LogPrintf("CActiveFivegnode::ManageStateInitial -- %s: %s\n", GetStateString(), strNotCapableReason);
         return;
     }

--- a/src/fivegnode.cpp
+++ b/src/fivegnode.cpp
@@ -305,7 +305,8 @@ bool CFivegnode::IsValidNetAddr(CService addrIn) {
     // TODO: regtest is fine with any addresses for now,
     // should probably be a bit smarter if one day we start to implement tests for this
     return Params().NetworkIDString() == CBaseChainParams::REGTEST ||
-           (addrIn.IsIPv4() && IsReachable(addrIn) && addrIn.IsRoutable());
+           ((addrIn.IsIPv4() || addrIn.IsIPv6()) &&
+            IsReachable(addrIn) && addrIn.IsRoutable());
 }
 
 bool CFivegnode::IsMyFivegnode(){

--- a/src/fivegnodeman.cpp
+++ b/src/fivegnodeman.cpp
@@ -409,7 +409,6 @@ int CFivegnodeMan::CountEnabled(int nProtocolVersion)
     return nCount;
 }
 
-/* Only IPv4 fivegnodes are allowed in 12.1, saving this for later
 int CFivegnodeMan::CountByIP(int nNetworkType)
 {
     LOCK(cs);
@@ -424,7 +423,6 @@ int CFivegnodeMan::CountByIP(int nNetworkType)
 
     return nNodeCount;
 }
-*/
 
 void CFivegnodeMan::DsegUpdate(CNode* pnode)
 {

--- a/src/fivegnodeman.h
+++ b/src/fivegnodeman.h
@@ -223,7 +223,7 @@ public:
     int CountEnabled(int nProtocolVersion = -1);
 
     /// Count Fivegnodes by network type - NET_IPV4, NET_IPV6, NET_TOR
-    // int CountByIP(int nNetworkType);
+    int CountByIP(int nNetworkType);
 
     void DsegUpdate(CNode* pnode);
 


### PR DESCRIPTION
## Summary
- permit IPv6 addresses in `CFivegnode::IsValidNetAddr`
- remove IPv4-only restriction when detecting local address
- relax startup error message about IPv4
- re-enable `CountByIP` helper for IPv6 counts
