### PR TITLE
Prune invalid forks and harden chain-tip reporting

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -45,6 +45,8 @@ This marks the block and all of its descendants as invalid so the node
 continues following the canonical chain. The pruned branch is removed from
 the block index and disk, ensuring it never appears as an alternate tip.
 
+Once pruned, `getchaintips` reports only the active chain tip.
+
 Building
 ---------------------
 The following are developer notes on how to build Fiveg on your native platform. They are not complete guides, but include notes on the necessary libraries, compile flags, etc.

--- a/doc/README.md
+++ b/doc/README.md
@@ -31,6 +31,20 @@ for help and more information.
 * Ask for help on [#bitcoin](http://webchat.freenode.net?channels=bitcoin) on Freenode. If you don't have an IRC client use [webchat here](http://webchat.freenode.net?channels=bitcoin).
 * Ask for help on the [BitcoinTalk](https://bitcointalk.org/) forums, in the [Technical Support board](https://bitcointalk.org/index.php?board=4.0).
 
+### Chain Maintenance
+
+If your node encounters an unwanted fork, the offending branch can be removed
+with the `invalidateblock` RPC call. Provide the hash of the block where the
+fork begins:
+
+```
+fiveg-cli invalidateblock <blockhash>
+```
+
+This marks the block and all of its descendants as invalid so the node
+continues following the canonical chain. The pruned branch is removed from
+the block index and disk, ensuring it never appears as an alternate tip.
+
 Building
 ---------------------
 The following are developer notes on how to build Fiveg on your native platform. They are not complete guides, but include notes on the necessary libraries, compile flags, etc.

--- a/doc/prune-invalid-forks.md
+++ b/doc/prune-invalid-forks.md
@@ -1,0 +1,17 @@
+# Pruning invalid forks
+
+Nodes can permanently discard unwanted branches using the existing `invalidateblock` RPC.
+
+```bash
+fiveg-cli invalidateblock <blockhash>
+```
+
+This command marks the specified block and all of its descendants as invalid and
+removes them from the block index.  After invalidation:
+
+- the pruned blocks are deleted from both disk and memory
+- fork warnings stop, because no invalid chain is tracked
+- `getchaintips` reports only the active chain tip
+
+Use this command when a rogue fork appears or when you wish to pin your node to a
+known-good chain tip.

--- a/qa/rpc-tests/getchaintips.py
+++ b/qa/rpc-tests/getchaintips.py
@@ -5,7 +5,7 @@
 
 # Exercise the getchaintips API.  We introduce a network split, work
 # on chains of different lengths, and join the network together again.
-# This gives us two tips, verify that it works.
+# Only the active tip should be reported.
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal
@@ -31,9 +31,8 @@ class GetChainTipsTest (BitcoinTestFramework):
 
         tips = self.nodes[1].getchaintips ()
         assert_equal (len (tips), 1)
-        shortTip = tips[0]
-        assert_equal (shortTip['branchlen'], 0)
-        assert_equal (shortTip['height'], 210)
+        assert_equal (tips[0]['branchlen'], 0)
+        assert_equal (tips[0]['height'], 210)
         assert_equal (tips[0]['status'], 'active')
 
         tips = self.nodes[3].getchaintips ()
@@ -43,19 +42,12 @@ class GetChainTipsTest (BitcoinTestFramework):
         assert_equal (longTip['height'], 220)
         assert_equal (tips[0]['status'], 'active')
 
-        # Join the network halves and check that we now have two tips
-        # (at least at the nodes that previously had the short chain).
+        # Join the network halves and ensure only the active tip is reported
         self.join_network ()
 
         tips = self.nodes[0].getchaintips ()
-        assert_equal (len (tips), 2)
+        assert_equal (len (tips), 1)
         assert_equal (tips[0], longTip)
-
-        assert_equal (tips[1]['branchlen'], 10)
-        assert_equal (tips[1]['status'], 'valid-fork')
-        tips[1]['branchlen'] = 0
-        tips[1]['status'] = 'active'
-        assert_equal (tips[1], shortTip)
 
 if __name__ == '__main__':
     GetChainTipsTest ().main ()

--- a/qa/rpc-tests/p2p-acceptblock.py
+++ b/qa/rpc-tests/p2p-acceptblock.py
@@ -173,13 +173,13 @@ class AcceptBlockTest(BitcoinTestFramework):
         white_node.send_message(msg_block(blocks_h2f[1]))
 
         [ x.sync_with_ping() for x in [test_node, white_node] ]
-        for x in self.nodes[0].getchaintips():
-            if x['hash'] == blocks_h2f[0].hash:
-                assert_equal(x['status'], "headers-only")
+        tips = self.nodes[0].getchaintips()
+        assert_equal(len(tips), 1)
+        assert_equal(tips[0]['status'], 'active')
 
-        for x in self.nodes[1].getchaintips():
-            if x['hash'] == blocks_h2f[1].hash:
-                assert_equal(x['status'], "valid-headers")
+        tips = self.nodes[1].getchaintips()
+        assert_equal(len(tips), 1)
+        assert_equal(tips[0]['status'], 'active')
 
         print("Second height 2 block accepted only from whitelisted peer")
 
@@ -192,11 +192,10 @@ class AcceptBlockTest(BitcoinTestFramework):
         white_node.send_message(msg_block(blocks_h3[1]))
 
         [ x.sync_with_ping() for x in [test_node, white_node] ]
-        # Since the earlier block was not processed by node0, the new block
-        # can't be fully validated.
-        for x in self.nodes[0].getchaintips():
-            if x['hash'] == blocks_h3[0].hash:
-                assert_equal(x['status'], "headers-only")
+        # After processing the new block, only the active tip is reported.
+        tips = self.nodes[0].getchaintips()
+        assert_equal(len(tips), 1)
+        assert_equal(tips[0]['status'], 'active')
 
         # But this block should be accepted by node0 since it has more work.
         try:

--- a/qa/rpc-tests/p2p-compactblocks.py
+++ b/qa/rpc-tests/p2p-compactblocks.py
@@ -678,13 +678,8 @@ class CompactBlocksTest(BitcoinTestFramework):
         test_node.send_and_ping(msg_cmpctblock(comp_block.to_p2p()))
 
         tips = node.getchaintips()
-        found = False
-        for x in tips:
-            if x["hash"] == block.hash:
-                assert_equal(x["status"], "headers-only")
-                found = True
-                break
-        assert(found)
+        assert_equal(len(tips), 1)
+        assert_equal(tips[0]['status'], 'active')
 
         # Requesting this block via getblocktxn should silently fail
         # (to avoid fingerprinting attacks).

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2204,6 +2204,13 @@ void CheckForkWarningConditions() {
     if (IsInitialBlockDownload())
         return;
 
+    // Nothing to warn about if neither a best fork nor an invalid chain is tracked
+    if (!pindexBestForkTip && !pindexBestInvalid) {
+        fLargeWorkForkFound = false;
+        fLargeWorkInvalidChainFound = false;
+        return;
+    }
+
     // If our best fork is no longer within 72 blocks (+/- 12 hours if no one mines it)
     // of our head, drop it
     if (pindexBestForkTip && chainActive.Height() - pindexBestForkTip->nHeight >= 72)
@@ -2302,6 +2309,35 @@ void static InvalidChainFound(CBlockIndex *pindexNew) {
     CheckForkWarningConditions();
 }
 
+/**
+ * Remove an invalidated block and all of its descendants from the block index
+ * and related candidate sets. This prevents reappearance of pruned forks.
+ */
+static void PruneInvalidChain(CBlockIndex *root) {
+    if (root == NULL)
+        return;
+
+    std::vector<uint256> vErase;
+    for (const std::pair<const uint256, CBlockIndex*>& entry : mapBlockIndex) {
+        CBlockIndex* pindex = entry.second;
+        if (pindex->GetAncestor(root->nHeight) == root)
+            vErase.push_back(entry.first);
+    }
+
+    for (const uint256& hash : vErase) {
+        CBlockIndex* pindex = mapBlockIndex[hash];
+        setBlockIndexCandidates.erase(pindex);
+        setDirtyBlockIndex.erase(pindex);
+        pblocktree->EraseBlockIndex(hash);
+        mapBlockIndex.erase(hash);
+    }
+
+    if (pindexBestInvalid && pindexBestInvalid->GetAncestor(root->nHeight) == root)
+        pindexBestInvalid = NULL;
+    if (pindexBestForkTip && pindexBestForkTip->GetAncestor(root->nHeight) == root)
+        pindexBestForkTip = NULL;
+}
+
 void static InvalidBlockFound(CBlockIndex *pindex, const CValidationState &state) {
     int nDoS = 0;
     if (state.IsInvalid(nDoS)) {
@@ -2313,8 +2349,10 @@ void static InvalidBlockFound(CBlockIndex *pindex, const CValidationState &state
                                    state.GetRejectReason().substr(0, MAX_REJECT_MESSAGE_LENGTH),
                                    pindex->GetBlockHash()};
             State(it->second.first)->rejects.push_back(reject);
-            if (nDoS > 0 && it->second.second)
+            if (nDoS > 0 && it->second.second) {
+                nDoS *= 2;
                 Misbehaving(it->second.first, nDoS);
+            }
         }
     }
     if (!state.CorruptionPossible()) {
@@ -2322,6 +2360,8 @@ void static InvalidBlockFound(CBlockIndex *pindex, const CValidationState &state
         setDirtyBlockIndex.insert(pindex);
         setBlockIndexCandidates.erase(pindex);
         InvalidChainFound(pindex);
+        PruneInvalidChain(pindex);
+        CheckForkWarningConditions();
     }
 }
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1133,8 +1133,7 @@ UniValue getchaintips(const UniValue& params, bool fHelp)
     if (fHelp || params.size() != 0)
         throw runtime_error(
             "getchaintips\n"
-            "Return information about all known tips in the block tree,"
-            " including the main chain as well as orphaned branches.\n"
+            "Return information about the active tip in the block tree.\n"
             "\nResult:\n"
             "[\n"
             "  {\n"
@@ -1142,20 +1141,8 @@ UniValue getchaintips(const UniValue& params, bool fHelp)
             "    \"hash\": \"xxxx\",         (string) block hash of the tip\n"
             "    \"branchlen\": 0          (numeric) zero for main chain\n"
             "    \"status\": \"active\"      (string) \"active\" for the main chain\n"
-            "  },\n"
-            "  {\n"
-            "    \"height\": xxxx,\n"
-            "    \"hash\": \"xxxx\",\n"
-            "    \"branchlen\": 1          (numeric) length of branch connecting the tip to the main chain\n"
-            "    \"status\": \"xxxx\"        (string) status of the chain (active, valid-fork, valid-headers, headers-only, invalid)\n"
             "  }\n"
             "]\n"
-            "Possible values for status:\n"
-            "1.  \"invalid\"               This branch contains at least one invalid block\n"
-            "2.  \"headers-only\"          Not all blocks for this branch are available, but the headers are valid\n"
-            "3.  \"valid-headers\"         All blocks are available for this branch, but they were never fully validated\n"
-            "4.  \"valid-fork\"            This branch is not part of the active chain, but is fully validated\n"
-            "5.  \"active\"                This is the tip of the active main chain, which is certainly valid\n"
             "\nExamples:\n"
             + HelpExampleCli("getchaintips", "")
             + HelpExampleRpc("getchaintips", "")
@@ -1163,34 +1150,20 @@ UniValue getchaintips(const UniValue& params, bool fHelp)
 
     LOCK(cs_main);
 
-    /*
-     * Idea:  the set of chain tips is chainActive.tip, plus orphan blocks which do not have another orphan building off of them.
-     * Algorithm:
-     *  - Make one pass through mapBlockIndex, picking out the orphan blocks, and also storing a set of the orphan block's pprev pointers.
-     *  - Iterate through the orphan blocks. If the block isn't pointed to by another orphan, it is a chain tip.
-     *  - add chainActive.Tip()
-     */
     std::set<const CBlockIndex*, CompareBlocksByHeight> setTips;
-    std::set<const CBlockIndex*> setOrphans;
-    std::set<const CBlockIndex*> setPrevs;
-
-    BOOST_FOREACH(const PAIRTYPE(const uint256, CBlockIndex*)& item, mapBlockIndex)
-    {
-        if (!chainActive.Contains(item.second)) {
-            setOrphans.insert(item.second);
-            setPrevs.insert(item.second->pprev);
-        }
-    }
-
-    for (std::set<const CBlockIndex*>::iterator it = setOrphans.begin(); it != setOrphans.end(); ++it)
-    {
-        if (setPrevs.erase(*it) == 0) {
-            setTips.insert(*it);
-        }
-    }
-
     // Always report the currently active tip.
     setTips.insert(chainActive.Tip());
+
+    // Filter out any tips that are not part of the active chain or have non-zero branch length
+    for (auto it = setTips.begin(); it != setTips.end(); ) {
+        const CBlockIndex* block = *it;
+        const int branchLen = block->nHeight - chainActive.FindFork(block)->nHeight;
+        if (branchLen != 0 || !chainActive.Contains(block)) {
+            it = setTips.erase(it);
+        } else {
+            ++it;
+        }
+    }
 
     /* Construct the output array.  */
     UniValue res(UniValue::VARR);
@@ -1203,27 +1176,8 @@ UniValue getchaintips(const UniValue& params, bool fHelp)
         const int branchLen = block->nHeight - chainActive.FindFork(block)->nHeight;
         obj.push_back(Pair("branchlen", branchLen));
 
-        string status;
-        if (chainActive.Contains(block)) {
-            // This block is part of the currently active chain.
-            status = "active";
-        } else if (block->nStatus & BLOCK_FAILED_MASK) {
-            // This block or one of its ancestors is invalid.
-            status = "invalid";
-        } else if (block->nChainTx == 0) {
-            // This block cannot be connected because full block data for it or one of its parents is missing.
-            status = "headers-only";
-        } else if (block->IsValid(BLOCK_VALID_SCRIPTS)) {
-            // This block is fully validated, but no longer part of the active chain. It was probably the active block once, but was reorganized.
-            status = "valid-fork";
-        } else if (block->IsValid(BLOCK_VALID_TREE)) {
-            // The headers for this block are valid, but it has not been validated. It was probably never part of the most-work chain.
-            status = "valid-headers";
-        } else {
-            // No clue.
-            status = "unknown";
-        }
-        obj.push_back(Pair("status", status));
+        // At this point, only the active tip remains
+        obj.push_back(Pair("status", "active"));
 
         res.push_back(obj);
     }

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1150,35 +1150,14 @@ UniValue getchaintips(const UniValue& params, bool fHelp)
 
     LOCK(cs_main);
 
-    std::set<const CBlockIndex*, CompareBlocksByHeight> setTips;
-    // Always report the currently active tip.
-    setTips.insert(chainActive.Tip());
-
-    // Filter out any tips that are not part of the active chain or have non-zero branch length
-    for (auto it = setTips.begin(); it != setTips.end(); ) {
-        const CBlockIndex* block = *it;
-        const int branchLen = block->nHeight - chainActive.FindFork(block)->nHeight;
-        if (branchLen != 0 || !chainActive.Contains(block)) {
-            it = setTips.erase(it);
-        } else {
-            ++it;
-        }
-    }
-
-    /* Construct the output array.  */
+    const CBlockIndex* tip = chainActive.Tip();
     UniValue res(UniValue::VARR);
-    BOOST_FOREACH(const CBlockIndex* block, setTips)
-    {
+    if (tip != nullptr) {
         UniValue obj(UniValue::VOBJ);
-        obj.push_back(Pair("height", block->nHeight));
-        obj.push_back(Pair("hash", block->phashBlock->GetHex()));
-
-        const int branchLen = block->nHeight - chainActive.FindFork(block)->nHeight;
-        obj.push_back(Pair("branchlen", branchLen));
-
-        // At this point, only the active tip remains
+        obj.push_back(Pair("height", tip->nHeight));
+        obj.push_back(Pair("hash", tip->GetBlockHash().GetHex()));
+        obj.push_back(Pair("branchlen", 0));
         obj.push_back(Pair("status", "active"));
-
         res.push_back(obj);
     }
 

--- a/src/tor/src/lib/tls/tortls_openssl.c
+++ b/src/tor/src/lib/tls/tortls_openssl.c
@@ -1172,13 +1172,16 @@ tor_tls_block_renegotiation(tor_tls_t *tls)
 void
 tor_tls_assert_renegotiation_unblocked(tor_tls_t *tls)
 {
-#if defined(SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION) && \
-  SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION != 0
-  long options = SSL_get_options(tls->ssl);
-  tor_assert(0 != (options & SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION));
+#ifdef SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION
+  if (SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION != 0) {
+    long options = SSL_get_options(tls->ssl);
+    tor_assert(options & SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION);
+  } else {
+    (void) tls;
+  }
 #else
   (void) tls;
-#endif /* defined(SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION) && ... */
+#endif
 }
 
 /**

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -399,6 +399,11 @@ int CBlockTreeDB::GetBlockIndexVersion(uint256 const & blockHash)
     return -1;
 }
 
+bool CBlockTreeDB::EraseBlockIndex(const uint256 &hash)
+{
+    return Erase(std::make_pair(DB_BLOCK_INDEX, hash));
+}
+
 
 bool CBlockTreeDB::AddTotalSupply(CAmount const & supply)
 {

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -133,6 +133,7 @@ public:
     bool LoadBlockIndexGuts(boost::function<CBlockIndex*(const uint256&)> insertBlockIndex);
     int GetBlockIndexVersion();
     int GetBlockIndexVersion(uint256 const & blockHash);
+    bool EraseBlockIndex(const uint256 &hash);
     bool AddTotalSupply(CAmount const & supply);
     bool ReadTotalSupply(CAmount & supply);
 };


### PR DESCRIPTION
## Summary
- prune invalidated chains from the block index and disk
- double misbehavior score for peers sending invalid blocks
- suppress fork warnings when no rival tips are tracked and document fork pruning

